### PR TITLE
fix version/set.sh

### DIFF
--- a/version/set.sh
+++ b/version/set.sh
@@ -5,7 +5,7 @@ set -e
 # build will fail if there is neither .git nor version.h
 [ ! -d .git ] && exit
 
-G=$(git describe --dirty=.XXX)
+G=$(git describe --dirty=.XXX --always)
 V=$(echo $G | sed 's|-g*|.|g;s|[.]|-|')
 
 case $V in


### PR DESCRIPTION
`version/set.sh` failed as `git describe` bails out at `fatal: No names found, cannot describe anything`.

	this with: git version 2.37.1 (Apple Git-137.1)

the result looks accurate to me:

```console
$ ./nsnotify -V
Program: nsnotify
Version: 55800e3-XXX
Date:    2022-01-28 18:59:21 +0000
Author:  Tony Finch (dot@dotat.at)
URL:     http://dotat.at/prog/nsnotifyd/
```